### PR TITLE
GET /api/v1/mobilecommons-groups

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,51 @@
-## API
+# API
 
 All API requests require the `x-messaging-group-api-key` to be set in the headers.
+
+## Get Mobile Commons Groups
+
+Finds or creates the "Doing" and "Completed" Mobile Commons Groups that correspond to the Campaign, Campaign Run, and Environment query parameters passed.
+
+The response `data` has contains `doing` and `completed` properties set to the corresponding Mobile Commons Groups. Unfortunately, this endpoint can't be tested without creating live Groups on Mobile Commons, so please use caution!
+
+```
+GET /api/v1/mobilecommons-groups
+```
+
+### Required query parameters:
+
+* `campaign_id` -- The DoSomething Campaign ID
+* `campaign_run_id` -- The Campaign Run ID of the Doing/Completed activity
+* `environment` -- The server environment requesting the Groups. Expected values: `'thor'` | `'production'`
+
+
+#### Example Request
+```
+curl "http://localhost:5100/api/v1/mobilecommons-groups?campaign_id=123&campaign_run_id=456&environment=thor" \
+     -H "x-messaging-group-api-key: totallysecret"
+```
+
+#### Example Response
+```
+{
+  "data": {
+    "doing": {
+      "id": 296486,
+      "name": "campaign_id=123 run_id=456 field=doing env=thor",
+      "status": "active",
+      "size": 0
+    },
+    "completed": {
+      "id": 296492,
+      "name": "campaign_id=123 run_id=456 field=completed env=thor",
+      "status": "active",
+      "size": 0
+    }
+  }
+}
+```
+
+## To be deprecated
 
 #### Create a group
 

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -13,9 +13,9 @@ const auth = {
 
 /**
  * Executes a GET request to the Mobile Commons API.
- * @param  {string} path - API path to hit.
- * @param  {object} query - Data to pass to Mobile Commons.
- * @return {object|null}
+ * @param {string} path - API path to hit.
+ * @param {object} query - Query to pass to Mobile Commons.
+ * @returns {object|null}
  */
 function executeGet(path, query) {
   logger.debug(`mobilecommons.executeGet:${JSON.stringify(query)}`);
@@ -34,13 +34,12 @@ function executeGet(path, query) {
 /**
  * Executes a POST request to the Mobile Commons API.
  * Handles generic tasks such as URL formation & auth.
- * @param  {object} data - Data to pass to Mobile Commons.
- * @param  {string} path - API path to hit.
- * @return {object|null}
+ * @param {string} path - API path to hit.
+ * @param {object} data - Data to post to Mobile Commons.
+ * @returns {object|null}
  */
-function executePost(data, path) {
-  logger.debug(`mobilecommons.executePost:${path}`);
-  logger.debug(data);
+function executePost(path, data) {
+  logger.debug(`mobilecommons.executePost:${path} data:${JSON.stringify(data)}`);
 
   return request
     .post(`${uri}/${path}`)
@@ -60,7 +59,7 @@ module.exports = {
    * @return {Promise}
    */
   createGroup: function (groupName) {
-    return executePost({ name: groupName }, 'create_group');
+    return executePost('create_group', { name: groupName });
   },
 
   /**
@@ -96,7 +95,7 @@ module.exports = {
    * @return {Promise}
    */
   postGroup: function (groupName) {
-    return executePost({ name: groupName }, 'create_group')
+    return executePost('create_group', { name: groupName })
       .then((res) => {
         const postResponse = res.response.group[0]['$'];
         const data = {

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -72,18 +72,21 @@ module.exports = {
     return executeGet('groups', { group_name: groupName })
       .then((res) => {
         // Parse through the insanity.
-        const groupsResponse = res.response.groups[0];
-        if (!groupsResponse.group) {
+        const getResponse = res.response.groups[0];
+        if (!getResponse.group) {
           throw new Error('Group not found');
         }
-        const group = groupsResponse.group[0];
 
-        return {
-          id: group['$'].id,
-          status: group['$'].status,
+        const group = getResponse.group[0];
+        const data = {
+          id: Number(group['$'].id),
           name: group.name[0],
+          status: group['$'].status,
           size: Number(group.size[0]),
         };
+        logger.debug(`mobilecommons.getGroup success:${JSON.stringify(data)}`);
+
+        return data;
       });
   },
 
@@ -96,11 +99,15 @@ module.exports = {
     return executePost({ name: groupName }, 'create_group')
       .then((res) => {
         const postResponse = res.response.group[0]['$'];
-
-        return {
-          id: postResponse.id,
+        const data = {
+          id: Number(postResponse.id),
           name: postResponse.name,
+          status: 'active',
+          size: 0,
         };
+        logger.debug(`mobilecommons.postGroup success:${JSON.stringify(data)}`);
+
+        return data;
       });
   },
 }

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -12,10 +12,30 @@ const auth = {
 };
 
 /**
- * Make a request to the Mobile Commons API.
+ * Executes a GET request to the Mobile Commons API.
+ * @param  {string} path - API path to hit.
+ * @param  {object} query - Data to pass to Mobile Commons.
+ * @return {object|null}
+ */
+function executeGet(path, query) {
+  logger.debug(`mobilecommons.executeGet:${JSON.stringify(query)}`);
+
+  return request
+    .get(`${uri}/${path}`)
+    .query(query)
+    .auth(auth.user, auth.password)
+    .buffer()
+    .accept('xml')
+    .then(res => res.text)
+    .then(res => xml2js(res))
+    .catch(err => logger.error(err));
+}
+
+/**
+ * Executes a POST request to the Mobile Commons API.
  * Handles generic tasks such as URL formation & auth.
- * @param  {object} data Data to pass to Mobile Commons.
- * @param  {string} path API path to hit.
+ * @param  {object} data - Data to pass to Mobile Commons.
+ * @param  {string} path - API path to hit.
  * @return {object|null}
  */
 function executePost(data, path) {
@@ -33,13 +53,36 @@ function executePost(data, path) {
     .catch(err => logger.error(err));
 }
 
+function parseGroupsResponse(res) {
+  // Parse through the insanity.
+  const group = res.response.groups[0].group[0];
+
+  return {
+    id: group['$'].id,
+    status: group['$'].status,
+    name: group.name[0],
+    size: Number(group.size[0]),
+  };
+}
+
 module.exports = {
   /**
-   * Create a mobile commons group.
-   * @param  {string} groupName Identifier for this group.
+   * Create a Mobile Commons Group.
+   * @param  {string} groupName - Identifier for this group.
    * @return {Promise}
    */
-  createGroup: function(groupName) {
+  createGroup: function (groupName) {
     return executePost({ name: groupName }, 'create_group');
+  },
+
+  /**
+   * Get a Mobile Commons Group.
+   * @param  {string} groupName - Identifier for this group.
+   * @return {Promise}
+   */
+  getGroup: function (groupName) {
+    return executeGet('groups', { group_name: groupName })
+      .then(res => parseGroupsResponse(res))
+      .catch(err => err);
   }
 }

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -53,18 +53,6 @@ function executePost(data, path) {
     .catch(err => logger.error(err));
 }
 
-function parseGroupsResponse(res) {
-  // Parse through the insanity.
-  const group = res.response.groups[0].group[0];
-
-  return {
-    id: group['$'].id,
-    status: group['$'].status,
-    name: group.name[0],
-    size: Number(group.size[0]),
-  };
-}
-
 module.exports = {
   /**
    * Create a Mobile Commons Group.
@@ -82,7 +70,37 @@ module.exports = {
    */
   getGroup: function (groupName) {
     return executeGet('groups', { group_name: groupName })
-      .then(res => parseGroupsResponse(res))
-      .catch(err => err);
-  }
+      .then((res) => {
+        // Parse through the insanity.
+        const groupsResponse = res.response.groups[0];
+        if (!groupsResponse.group) {
+          throw new Error('Group not found');
+        }
+        const group = groupsResponse.group[0];
+
+        return {
+          id: group['$'].id,
+          status: group['$'].status,
+          name: group.name[0],
+          size: Number(group.size[0]),
+        };
+      });
+  },
+
+  /**
+   * Post a Mobile Commons Group.
+   * @param  {string} groupName - Identifier for this group.
+   * @return {Promise}
+   */
+  postGroup: function (groupName) {
+    return executePost({ name: groupName }, 'create_group')
+      .then((res) => {
+        const postResponse = res.response.group[0]['$'];
+
+        return {
+          id: postResponse.id,
+          name: postResponse.name,
+        };
+      });
+  },
 }

--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -15,6 +15,21 @@ function formatApiResponse(groupDoc) {
   };
 }
 
+function findOrCreateGroup(groupName) {
+  logger.debug(`findOrCreateGroup:${groupName}`);
+
+  return mobilecommons
+    .getGroup(groupName)
+    .then(res => res)
+    .catch((err) => {
+      if (err.message === 'Group not found') {
+        return mobilecommons.postGroup(groupName);
+      }
+  
+      return err;
+    });
+}
+
 module.exports = router => {
 
   // API key check
@@ -35,7 +50,7 @@ module.exports = router => {
   /**
    * Helper route to return a Mobile Commons Group by its name.
    */
-  router.get('/groups/', (req, res) => {
+  router.get('/mobilecommons-groups/', (req, res) => {
     const groupName = req.query.groupName;
     logger.debug(`GET groupName:'${groupName}'`);
 
@@ -45,6 +60,35 @@ module.exports = router => {
         logger.debug(mcRes);
 
         return res.send(mcRes);
+      })
+      .catch((err) => {
+        logger.error(err.message);
+        let status = 500;
+        if (err.message === 'Group not found') {
+          status = 404;
+        }
+
+        return res.status(status).send(err.message);
+      });
+  });
+
+  /**
+   * Helper route to find or create a Mobile Commons Group by its name.
+   */
+  router.post('/mobilecommons-groups/', (req, res) => {
+    const groupName = req.body.groupName;
+    if (!groupName) {
+      const msg = 'Missing parameters';
+      logger.warn(msg);
+      return res.send(msg).status(400);
+    }
+
+    return findOrCreateGroup(groupName)
+      .then(mcRes => res.send(mcRes))
+      .catch((err) => {
+        logger.error(err.message);
+
+        return res.status(500).send(err.message);
       });
   });
 

--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -3,9 +3,11 @@
 const logger = require('winston');
 const util = require('../util');
 const mobilecommons = require('../mobilecommons');
-
 const Group = require('../group');
 
+/**
+ * To be deprecated - used by POST /group
+ */
 function formatApiResponse(groupDoc) {
   return {
     id: groupDoc._id,
@@ -15,6 +17,11 @@ function formatApiResponse(groupDoc) {
   };
 }
 
+/**
+ * Returns a Mobile Commons Group for given groupName, creating it if it doesn't exist.
+ * @param {string} groupName - The name of the Mobile Commons Group.
+ * @returns {Promise}
+ */
 function findOrCreateGroup(groupName) {
   logger.debug(`findOrCreateGroup:${groupName}`);
 
@@ -23,6 +30,7 @@ function findOrCreateGroup(groupName) {
     .then(res => res)
     .catch((err) => {
       if (err.message === 'Group not found') {
+        logger.info(`findOrCreateGroup did not find group with name:'${groupName}'. Creating...`);
         return mobilecommons.postGroup(groupName);
       }
   
@@ -48,50 +56,50 @@ module.exports = router => {
   });
 
   /**
-   * Helper route to return a Mobile Commons Group by its name.
+   * Gets/posts to the Mobile Commons API to find/create the Mobile Commons groups for query params.
    */
   router.get('/mobilecommons-groups/', (req, res) => {
-    const groupName = req.query.groupName;
-    logger.debug(`GET groupName:'${groupName}'`);
-
-    return mobilecommons
-      .getGroup(groupName)
-      .then(mcRes => {
-        logger.debug(mcRes);
-
-        return res.send(mcRes);
-      })
-      .catch((err) => {
-        logger.error(err.message);
-        let status = 500;
-        if (err.message === 'Group not found') {
-          status = 404;
-        }
-
-        return res.status(status).send(err.message);
-      });
-  });
-
-  /**
-   * Helper route to find or create a Mobile Commons Group by its name.
-   */
-  router.post('/mobilecommons-groups/', (req, res) => {
-    const groupName = req.body.groupName;
-    if (!groupName) {
-      const msg = 'Missing parameters';
+    if (!util.validate(['campaign_id', 'campaign_run_id', 'environment'], req.query)) {
+      const status = 422;
+      const msg = 'Missing required query parameters.';
       logger.warn(msg);
-      return res.send(msg).status(400);
+
+      return res.status(status).send({
+        error: {
+          code: status,
+          message: msg,
+        },
+      });
     }
 
-    return findOrCreateGroup(groupName)
-      .then(mcRes => res.send(mcRes))
-      .catch((err) => {
-        logger.error(err.message);
+    const campaignId = req.query.campaign_id;
+    const campaignRunId = req.query.campaign_run_id;
+    const environment = req.query.environment;
+    const fields = ['doing', 'completed'];
+    const promises = [];
 
-        return res.status(500).send(err.message);
-      });
+    fields.forEach((fieldName) => {
+      const groupName = util.groupKeyGen(campaignId, campaignRunId, environment, fieldName);
+      promises.push(findOrCreateGroup(groupName));
+    });
+
+    Promise.all(promises)
+      .then((groups) => {
+        const data = {};
+        fields.forEach((fieldName, index) => {
+          return data[fieldName] = groups[index];
+        });
+
+        return res.send({ data });
+      })
+      .catch(err => res.status(500).send(err.message));
   });
 
+
+  /**
+   * To be deprecated.
+   * Queries Mongo to return a Group model for Campaign and its Run.
+   */
   router.get('/group/:campaignId/:campaignRunId', function (req, res) {
     // Validate request
     if (!util.validate(['campaignId', 'campaignRunId'], req.params)) {
@@ -127,6 +135,11 @@ module.exports = router => {
     });
   });
 
+  /**
+   * To be deprecated.
+   * Creates Mobile Commons Groups for all possible environments/fields with given Campaign and Run
+   * and returns a Group model.
+   */
   router.post('/group', function (req, res) {
     // Validate request
     if (!util.validate(['campaign_id', 'campaign_run_id'], req.body)) {

--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -32,6 +32,22 @@ module.exports = router => {
     res.json({'success': true});
   });
 
+  /**
+   * Helper route to return a Mobile Commons Group by its name.
+   */
+  router.get('/groups/', (req, res) => {
+    const groupName = req.query.groupName;
+    logger.debug(`GET groupName:'${groupName}'`);
+
+    return mobilecommons
+      .getGroup(groupName)
+      .then(mcRes => {
+        logger.debug(mcRes);
+
+        return res.send(mcRes);
+      });
+  });
+
   router.get('/group/:campaignId/:campaignRunId', function (req, res) {
     // Validate request
     if (!util.validate(['campaignId', 'campaignRunId'], req.params)) {


### PR DESCRIPTION
Adds new endpoint that finds or creates the Doing/Created Mobile Commons Groups for required query parameters:
* `campaign_id`
* `campaign_run_id`
* `environment`

Gambit will no longer need to handle the lifting of finding whether a Mobile Commons Group exists, making https://github.com/DoSomething/gambit/issues/845 easy to fix (we'll just change the Gambit `campaigns` router to simply GET `/mobilecommons-groups` instead of conditionally executing GET `/group` + POST `group` requests)

* Fixes #7: Queries the Mobile Commons `/groups` API with a `group_name` parameter to return Groups that have already been created for the given parameters.
* Fixes #4 
* Lays foundation to remove Group model and `/group` routes in #11 once Gambit is changed to query this endpoint